### PR TITLE
Fix build on riscv64

### DIFF
--- a/disassembler/regs.h
+++ b/disassembler/regs.h
@@ -6,6 +6,13 @@
 #undef REG_NONE // collides with winnt's define
 #endif
 
+#ifdef __riscv
+// On RISC-V musl defines REG_SP/REG_S0 in signal.h.
+// Similarily, glibc defines REG_SP/REG_S0 in sys/ucontext.h.
+#undef REG_SP
+#undef REG_S0
+#endie
+
 //-----------------------------------------------------------------------------
 // registers (non-system)
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
On RISC-V the REG_SP macro may be defined already. Undefine it to
prevent compiler errors. This should fix the radare2 build on riscv64.

See:

* https://www.openwall.com/lists/musl/2020/02/03/8
* https://git.musl-libc.org/cgit/musl/commit/arch/riscv64/bits/signal.h?id=329e79299daaa994b8e75941331a1093051ea5d9